### PR TITLE
install-operators: perform dnf clean to remove cached data

### DIFF
--- a/install-operators/Dockerfile
+++ b/install-operators/Dockerfile
@@ -1,3 +1,3 @@
 FROM quay.io/openshift/origin-cli 
 
-RUN dnf -y update && dnf -y install jq
+RUN dnf -y update && dnf -y install jq && dnf clean all


### PR DESCRIPTION
# Change

After dnf operations (e.g. install, update), we should run clean to remove cached packages. This will help to reduce the size of the container image.

**Before**

```
localhost/foo   latest      de054ea20e89  14 minutes ago  811 MB
```

**After**

```
localhost/foo  latest-2    6e0331de7b20  12 minutes ago  525 MB
```
